### PR TITLE
ref: STR-3825/MultiSchema Support

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -1081,12 +1081,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
     InternalUtils.assertNotEmpty("tableName", tableName);
     InternalUtils.assertNotEmpty("sourceChannelName", sourceChannelName);
     InternalUtils.assertNotEmpty("destinationChannelName", destinationChannelName);
-    String fullyQualifiedTableName =
-        jdbcProperties.getProperty(InternalUtils.JDBC_DATABASE)
-            + "."
-            + jdbcProperties.getProperty(InternalUtils.JDBC_SCHEMA)
-            + "."
-            + tableName;
+    String fullyQualifiedTableName = getFullyQualifiedTableName(tableName);
     String query = "select SYSTEM$SNOWPIPE_STREAMING_MIGRATE_CHANNEL_OFFSET_TOKEN((?), (?), (?));";
 
     try {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -684,7 +684,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
                   extraColNames == null ? "null" : String.join(",", extraColNames));
               SchematizationUtils.evolveSchemaIfNeeded(
                   this.conn,
-                  this.channel.getTableName(),
+                  String.join(".", this.channel.getSchemaName(), this.channel.getTableName()),
                   new ArrayList<>(nonNullableColumns),
                   extraColNames,
                   this.insertRowsStreamingBuffer.getSinkRecord(originalSinkRecordIdx),
@@ -1019,11 +1019,20 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
    * @return new channel which was fetched after open/reopen
    */
   private SnowflakeStreamingIngestChannel openChannelForTable() {
+    String sName=this.sfConnectorConfig.get(Utils.SF_SCHEMA);
+    String tName=this.tableName;
+    if(this.tableName.contains(".")){
+      String[] parts = this.tableName.split("\\.");
+      if(parts.length>=2){
+        sName = parts[parts.length-2];
+        tName = parts[parts.length-1];
+      }
+    }
     OpenChannelRequest channelRequest =
         OpenChannelRequest.builder(this.channelNameFormatV1)
             .setDBName(this.sfConnectorConfig.get(Utils.SF_DATABASE))
-            .setSchemaName(this.sfConnectorConfig.get(Utils.SF_SCHEMA))
-            .setTableName(this.tableName)
+            .setSchemaName(sName)
+            .setTableName(tName)
             .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
             .setOffsetTokenVerificationFunction(StreamingUtils.offsetTokenVerificationFunction)
             .build();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -4,7 +4,6 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MAX_GET_OFFSET_TOKEN_RETRIES;
 import static java.time.temporal.ChronoUnit.SECONDS;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MAX_GET_OFFSET_TOKEN_RETRIES;
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -533,7 +534,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
           || nullValueForNotNullColNames != null) {
         SchematizationUtils.evolveSchemaIfNeeded(
             this.conn,
-            this.channel.getTableName(),
+            String.join(".",this.channel.getSchemaName(), this.channel.getTableName()),
             join(nonNullableColumns, nullValueForNotNullColNames),
             extraColNames,
             kafkaSinkRecord,
@@ -809,11 +810,20 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
    * @return new channel which was fetched after open/reopen
    */
   private SnowflakeStreamingIngestChannel openChannelForTable() {
+    String sName=this.sfConnectorConfig.get(Utils.SF_SCHEMA);
+    String tName=this.tableName;
+    if(this.tableName.contains(".")){
+      String[] parts = this.tableName.split("\\.");
+      if(parts.length>=2){
+        sName = parts[parts.length-2];
+        tName = parts[parts.length-1];
+      }
+    }
     OpenChannelRequest channelRequest =
         OpenChannelRequest.builder(this.channelNameFormatV1)
             .setDBName(this.sfConnectorConfig.get(Utils.SF_DATABASE))
-            .setSchemaName(this.sfConnectorConfig.get(Utils.SF_SCHEMA))
-            .setTableName(this.tableName)
+            .setSchemaName(sName)
+            .setTableName(tName)
             .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
             .setOffsetTokenVerificationFunction(StreamingUtils.offsetTokenVerificationFunction)
             .build();


### PR DESCRIPTION
Tested it with following mapping which created tables in different schemas

`"snowflake.topic2table.map": "^.*\\.tabled:schema_a.tabled,^.*\\.tablea:schema_a.tablea, ^.*\\.tableb:schema_b.tableb, ^.*\\.tablec:schema_c.tablec"`