### PR TITLE
ENG-2289: add DEBUG log on successful insertRow

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -439,6 +439,11 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
               response.hasErrors());
 
           handleInsertRowFailure(response.getInsertErrors(), kafkaSinkRecord);
+        } else {
+          LOGGER.debug(
+              "insertRow succeeded with no validation errors for channel:{}, kafkaOffset:{}",
+              this.getChannelNameFormatV1(),
+              kafkaSinkRecord.kafkaOffset());
         }
       }
 


### PR DESCRIPTION
## Summary
Part of the ENG-2289 CI-warehouse investigation (streamkap-com/streamkap-snowflake-connect-pkg): diagnosing intermittent `assertSQL expected 1 but was 0` failures in `SnowflakeITAppend`, likely caused by schema-evolution-triggered channel invalidation eating into the test's flush-wait budget.

- `DirectTopicPartitionChannel.transformAndSend` previously logged nothing on the success path — no way to tell from logs whether a `put()` call actually delivered a record.
- Adds a single DEBUG line (channel name + kafka offset) on successful `insertRow`, purely additive, no behavior change.

## Test plan
- [x] `mvn -Dgpg.skip -Dmaven.javadoc.skip=true clean install -DskipTests` compiles clean
- [ ] Correlate this new log line against existing "Channel is invalid... reopen" warnings on the next CI run to determine whether channel-invalidation cycles are consuming the test's wait budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)