### PR TITLE
ENG-2504: stringify structured Iceberg RECORD_METADATA.key

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapper.java
@@ -56,21 +56,15 @@ class IcebergTableStreamingRecordMapper extends StreamingRecordMapper {
         .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
   }
 
-  private Map<String, Object> getMapForMetadata(JsonNode metadataNode)
+  // Visibility widened to protected (upstream: private) so StreamkapIcebergTableStreamingRecordMapper
+  // can override and post-process the metadata map. See ENG-2504.
+  protected Map<String, Object> getMapForMetadata(JsonNode metadataNode)
       throws JsonProcessingException {
     Map<String, Object> values = mapper.convertValue(metadataNode, OBJECTS_MAP_TYPE_REFERENCE);
     // we don't want headers to be serialized as Map<String, Object> so we overwrite it as
     // Map<String, String>
     Map<String, String> headers = convertHeaders(metadataNode.findValue(HEADERS));
     values.put(HEADERS, headers);
-    // ENG-2504: the Iceberg metadata schema hardcodes `key STRING`, but a structured/composite CDC
-    // key (object/array) arrives as JSON and fails to ingest into a STRING column. Stringify a
-    // non-textual key to JSON text (mirrors the headers handling above); textual keys pass through
-    // unchanged.
-    JsonNode keyNode = metadataNode.get(KEY);
-    if (keyNode != null && !keyNode.isNull()) {
-      values.put(KEY, getTextualValue(keyNode));
-    }
     return values;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapper.java
@@ -63,6 +63,14 @@ class IcebergTableStreamingRecordMapper extends StreamingRecordMapper {
     // Map<String, String>
     Map<String, String> headers = convertHeaders(metadataNode.findValue(HEADERS));
     values.put(HEADERS, headers);
+    // ENG-2504: the Iceberg metadata schema hardcodes `key STRING`, but a structured/composite CDC
+    // key (object/array) arrives as JSON and fails to ingest into a STRING column. Stringify a
+    // non-textual key to JSON text (mirrors the headers handling above); textual keys pass through
+    // unchanged.
+    JsonNode keyNode = metadataNode.get(KEY);
+    if (keyNode != null && !keyNode.isNull()) {
+      values.put(KEY, getTextualValue(keyNode));
+    }
     return values;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordServiceFactory.java
@@ -7,8 +7,10 @@ public class RecordServiceFactory {
       boolean isIcebergEnabled, boolean enableSchematization) {
     ObjectMapper objectMapper = new ObjectMapper();
     if (isIcebergEnabled) {
+      // Streamkap override (ENG-2504): stringifies structured Iceberg RECORD_METADATA.key.
       return new RecordService(
-          new IcebergTableStreamingRecordMapper(objectMapper, enableSchematization), objectMapper);
+          new StreamkapIcebergTableStreamingRecordMapper(objectMapper, enableSchematization),
+          objectMapper);
     } else {
       return new RecordService(
           new SnowflakeTableStreamingRecordMapper(objectMapper, enableSchematization),

--- a/src/main/java/com/snowflake/kafka/connector/records/StreamkapIcebergTableStreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/StreamkapIcebergTableStreamingRecordMapper.java
@@ -1,0 +1,35 @@
+package com.snowflake.kafka.connector.records;
+
+import static com.snowflake.kafka.connector.records.RecordService.KEY;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+
+/**
+ * Streamkap override of {@link IcebergTableStreamingRecordMapper}. Keeps fork customisations out of
+ * the upstream mapper so future Snowflake merges stay low-conflict (see package CLAUDE.md).
+ *
+ * <p>ENG-2504: the Iceberg metadata schema hardcodes {@code key STRING}, but a structured/composite
+ * CDC key (JSON object/array) fails to ingest into a STRING column. We stringify a non-textual key
+ * to JSON text (mirroring upstream's own headers handling); textual keys pass through unchanged.
+ */
+class StreamkapIcebergTableStreamingRecordMapper extends IcebergTableStreamingRecordMapper {
+
+  public StreamkapIcebergTableStreamingRecordMapper(
+      ObjectMapper objectMapper, boolean schematizationEnabled) {
+    super(objectMapper, schematizationEnabled);
+  }
+
+  @Override
+  protected Map<String, Object> getMapForMetadata(JsonNode metadataNode)
+      throws JsonProcessingException {
+    Map<String, Object> values = super.getMapForMetadata(metadataNode);
+    JsonNode keyNode = metadataNode.get(KEY);
+    if (keyNode != null && !keyNode.isNull()) {
+      values.put(KEY, getTextualValue(keyNode));
+    }
+    return values;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
@@ -278,21 +278,7 @@ class IcebergTableStreamingRecordMapperTest {
         Arguments.of(
             "Metadata with null field value",
             buildRow("{}", "{\"offset\": null}"),
-            mapWithNullableValuesOf("offset", null, "headers", ImmutableMap.of())),
-        // ENG-2504: structured/composite CDC keys must be stringified to JSON text so they fit the
-        // hardcoded `key STRING` Iceberg metadata column instead of failing ingestion.
-        Arguments.of(
-            "Metadata with plain string key is preserved",
-            buildRow("{}", "{\"key\": \"pk-123\", \"headers\": {}}"),
-            ImmutableMap.of("key", "pk-123", "headers", ImmutableMap.of())),
-        Arguments.of(
-            "Metadata with structured (composite) key is stringified",
-            buildRow("{}", "{\"key\": {\"id\": 1, \"sub\": \"a\"}, \"headers\": {}}"),
-            ImmutableMap.of("key", "{\"id\":1,\"sub\":\"a\"}", "headers", ImmutableMap.of())),
-        Arguments.of(
-            "Metadata with array key is stringified",
-            buildRow("{}", "{\"key\": [1, 2], \"headers\": {}}"),
-            ImmutableMap.of("key", "[1,2]", "headers", ImmutableMap.of())));
+            mapWithNullableValuesOf("offset", null, "headers", ImmutableMap.of())));
   }
 
   private static Stream<Arguments> prepareNoSchematizationData() throws JsonProcessingException {

--- a/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
@@ -278,7 +278,21 @@ class IcebergTableStreamingRecordMapperTest {
         Arguments.of(
             "Metadata with null field value",
             buildRow("{}", "{\"offset\": null}"),
-            mapWithNullableValuesOf("offset", null, "headers", ImmutableMap.of())));
+            mapWithNullableValuesOf("offset", null, "headers", ImmutableMap.of())),
+        // ENG-2504: structured/composite CDC keys must be stringified to JSON text so they fit the
+        // hardcoded `key STRING` Iceberg metadata column instead of failing ingestion.
+        Arguments.of(
+            "Metadata with plain string key is preserved",
+            buildRow("{}", "{\"key\": \"pk-123\", \"headers\": {}}"),
+            ImmutableMap.of("key", "pk-123", "headers", ImmutableMap.of())),
+        Arguments.of(
+            "Metadata with structured (composite) key is stringified",
+            buildRow("{}", "{\"key\": {\"id\": 1, \"sub\": \"a\"}, \"headers\": {}}"),
+            ImmutableMap.of("key", "{\"id\":1,\"sub\":\"a\"}", "headers", ImmutableMap.of())),
+        Arguments.of(
+            "Metadata with array key is stringified",
+            buildRow("{}", "{\"key\": [1, 2], \"headers\": {}}"),
+            ImmutableMap.of("key", "[1,2]", "headers", ImmutableMap.of())));
   }
 
   private static Stream<Arguments> prepareNoSchematizationData() throws JsonProcessingException {

--- a/src/test/java/com/snowflake/kafka/connector/records/StreamkapIcebergTableStreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/StreamkapIcebergTableStreamingRecordMapperTest.java
@@ -1,0 +1,65 @@
+package com.snowflake.kafka.connector.records;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.records.RecordService.SnowflakeTableRow;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * ENG-2504: covers the Streamkap override that stringifies a structured/composite Iceberg
+ * RECORD_METADATA.key so it fits the hardcoded `key STRING` column instead of failing ingestion.
+ * Upstream metadata handling is covered by {@link IcebergTableStreamingRecordMapperTest}.
+ */
+class StreamkapIcebergTableStreamingRecordMapperTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("prepareKeyData")
+  void shouldStringifyStructuredMetadataKey(
+      String description, SnowflakeTableRow row, Map<String, Object> expected)
+      throws JsonProcessingException {
+    StreamkapIcebergTableStreamingRecordMapper mapper =
+        new StreamkapIcebergTableStreamingRecordMapper(objectMapper, false);
+    StreamkapIcebergTableStreamingRecordMapper mapperSchematization =
+        new StreamkapIcebergTableStreamingRecordMapper(objectMapper, true);
+
+    Map<String, Object> result = mapper.processSnowflakeRecord(row, true);
+    Map<String, Object> resultSchematized = mapperSchematization.processSnowflakeRecord(row, true);
+
+    assertThat(result.get(Utils.TABLE_COLUMN_METADATA)).isEqualTo(expected);
+    assertThat(resultSchematized.get(Utils.TABLE_COLUMN_METADATA)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> prepareKeyData() throws JsonProcessingException {
+    return Stream.of(
+        // A plain string key is unchanged (proves upstream behaviour is preserved).
+        Arguments.of(
+            "Plain string key is preserved",
+            buildRow("{\"key\": \"pk-123\", \"headers\": {}}"),
+            ImmutableMap.of("key", "pk-123", "headers", ImmutableMap.of())),
+        // A structured/composite key is serialized to JSON text.
+        Arguments.of(
+            "Structured (composite) key is stringified",
+            buildRow("{\"key\": {\"id\": 1, \"sub\": \"a\"}, \"headers\": {}}"),
+            ImmutableMap.of("key", "{\"id\":1,\"sub\":\"a\"}", "headers", ImmutableMap.of())),
+        // An array key is serialized to JSON text.
+        Arguments.of(
+            "Array key is stringified",
+            buildRow("{\"key\": [1, 2], \"headers\": {}}"),
+            ImmutableMap.of("key", "[1,2]", "headers", ImmutableMap.of())));
+  }
+
+  private static SnowflakeTableRow buildRow(String metadata) throws JsonProcessingException {
+    return new SnowflakeTableRow(
+        new SnowflakeRecordContent(objectMapper.readTree("{}")),
+        objectMapper.readTree(metadata));
+  }
+}


### PR DESCRIPTION
## Problem
In Snowflake-managed Iceberg mode, `IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA` hardcodes a `key STRING` metadata column. A structured/composite CDC key (a JSON object/array) fails ingestion:

```
SFException: Object of type java.util.LinkedHashMap cannot be ingested into
Snowflake column RECORD_METADATA.key of type STRING
```

`RecordService.putKey` sets a structured key as a JSON object node; the Iceberg mapper stringified `headers` but passed `key` through unchanged. Classic mode avoids this via a single VARIANT column.

## Fix
Follows the fork's **extend-don't-modify** convention (see package `CLAUDE.md`), keeping upstream low-conflict for the imminent v3.5.4 merge:

- **New `StreamkapIcebergTableStreamingRecordMapper`** overrides `getMapForMetadata`: calls `super`, then coerces a non-textual `key` to JSON text via the existing `getTextualValue` helper. Textual keys pass through unchanged.
- **`RecordServiceFactory`** injects the Streamkap subclass for Iceberg (mirrors how `StreamkapSnowflakeColumnTypeMapper` is wired).
- **Only upstream-class change:** `IcebergTableStreamingRecordMapper.getMapForMetadata` `private` → `protected` so the override dispatches.

**No DDL change.** Replaces the per-connector `ExtractField$Key` + `Cast$Key` SMT workaround (single-column, non-optional PK only) and supports **composite keys** connector-side.

## Tests
Upstream `IcebergTableStreamingRecordMapperTest` left **byte-identical to upstream**. Streamkap override covered by new `StreamkapIcebergTableStreamingRecordMapperTest` — object key, array key, plain-string key (proves existing behaviour is preserved). Verified the structured cases fail without the fix; full `records`-package suite green (JDK 17).

## Upstream note
Not fixed in any newer upstream version: `IcebergDDLTypes` + mapper are byte-identical v3.2.2→v3.5.4, and v4.x (through v4.1.0-rc1) still hardcodes `key STRING` while `SnowflakeSinkRecord.addKeyToMetadata` leaves composite keys as structured objects (only its exception path stringifies). Carry-forward logged for the v4 migration (ENG-2530/2532).

Linear: https://linear.app/streamkap/issue/ENG-2504

🤖 Generated with [Claude Code](https://claude.com/claude-code)