### PR TITLE
ENG-2589: emit UTC offset for Debezium timestamps (fix DST +1h)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -330,9 +330,15 @@ public boolean setAndGetAutoSchematizationFromConfig(
   }
 
   private static JsonNode convertDebeziumTimestampToTextNode(long value, long nanosMultiplier) {
+    // ENG-2589: emit an explicit UTC offset (…Z), not a bare local date-time. Debezium
+    // Timestamp/Micro/Nano are epoch-based (a UTC instant); an offset-less string is ambiguous, and
+    // the Snowpipe Streaming ingest SDK parses it via LocalDateTime.atZone(<hardcoded LA default>) →
+    // a DST-gap +1h shift on typed TIMESTAMP columns. ISO_OFFSET_DATE_TIME makes the value
+    // self-describing (SDK takes its OffsetDateTime/UTC branch) while keeping the same fraction
+    // handling (nanoseconds preserved). TIME/DATE helpers stay offset-less by design.
     return JsonNodeFactory.instance.textNode(
         Instant.ofEpochSecond(0, value * nanosMultiplier).atZone(ZoneOffset.UTC)
-            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+            .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -381,7 +381,7 @@ public class ConverterTest {
 
     JsonNode result = RecordService.convertToJson(schemaInputValue.schema(), schemaInputValue.value(), false);
 
-    assertEquals("1970-01-02T00:00:00", result.asText());
+    assertEquals("1970-01-02T00:00:00Z", result.asText());
   }
 
   @Test
@@ -398,7 +398,7 @@ public class ConverterTest {
 
     JsonNode result = RecordService.convertToJson(schemaInputValue.schema(), schemaInputValue.value(), false);
 
-    assertEquals("1970-01-02T00:00:00", result.asText());
+    assertEquals("1970-01-02T00:00:00Z", result.asText());
   }
 
   @Test
@@ -415,7 +415,7 @@ public class ConverterTest {
 
     JsonNode result = RecordService.convertToJson(schemaInputValue.schema(), schemaInputValue.value(), false);
 
-    assertEquals("1970-01-02T00:00:00", result.asText());
+    assertEquals("1970-01-02T00:00:00Z", result.asText());
   }
 
   @Test
@@ -485,14 +485,42 @@ public class ConverterTest {
       JsonConverter jsonConverter = new JsonConverter();
       jsonConverter.configure(Map.of("schemas.enable", true), false);
 
-      // 2026-01-15T12:00:00Z -- EST (UTC-5) in America/New_York
-      assertEquals("2026-01-15T12:00:00", convertDebeziumTimestamp(jsonConverter, 1768478400000L));
+      // ENG-2589: output now carries an explicit UTC offset (…Z) so the ingest SDK can't re-coerce
+      // it by its hardcoded default zone. 2026-01-15T12:00:00Z -- EST (UTC-5) in America/New_York
+      assertEquals("2026-01-15T12:00:00Z", convertDebeziumTimestamp(jsonConverter, 1768478400000L));
       // 2026-07-15T12:00:00Z -- EDT (UTC-4) in America/New_York
-      assertEquals("2026-07-15T12:00:00", convertDebeziumTimestamp(jsonConverter, 1784116800000L));
-      // 2026-03-08T02:20:49Z -- the exact value cited in this PR's own test plan as an example
-      // DST-gap value. Under the buggy ZoneId.systemDefault() code this reinterprets as
-      // 2026-03-07T21:20:49 (-5h, EST); under UTC it must round-trip unchanged.
-      assertEquals("2026-03-08T02:20:49", convertDebeziumTimestamp(jsonConverter, 1772936449000L));
+      assertEquals("2026-07-15T12:00:00Z", convertDebeziumTimestamp(jsonConverter, 1784116800000L));
+      // 2026-03-08T02:20:49Z -- DST-gap value. Under the buggy ZoneId.systemDefault() code this
+      // reinterprets as 2026-03-07T21:20:49 (-5h, EST); under UTC it must round-trip unchanged.
+      assertEquals("2026-03-08T02:20:49Z", convertDebeziumTimestamp(jsonConverter, 1772936449000L));
+    } finally {
+      TimeZone.setDefault(original);
+    }
+  }
+
+  /**
+   * ENG-2589: scalar Debezium Micro/Nano timestamps must also emit an explicit UTC offset, at full
+   * precision, at a DST spring-forward gap value (2025-03-09T02:30 -- a nonexistent local time in US
+   * DST zones, where an offset-less string would be pushed +1h by the downstream ingest SDK).
+   */
+  @Test
+  public void testDebeziumMicroAndNanoTimestamp_emitUtcOffsetAtFullPrecision() {
+    TimeZone original = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+
+      // 2025-03-09T02:30:00.123456789Z as nanoseconds since epoch
+      Schema nano = SchemaBuilder.int64().name("io.debezium.time.NanoTimestamp").version(1).build();
+      assertEquals(
+          "2025-03-09T02:30:00.123456789Z",
+          RecordService.convertToJson(nano, 1741487400123456789L, false).asText());
+
+      // 2025-03-09T02:30:00.123456Z as microseconds since epoch
+      Schema micro =
+          SchemaBuilder.int64().name("io.debezium.time.MicroTimestamp").version(1).build();
+      assertEquals(
+          "2025-03-09T02:30:00.123456Z",
+          RecordService.convertToJson(micro, 1741487400123456L, false).asText());
     } finally {
       TimeZone.setDefault(original);
     }
@@ -528,8 +556,8 @@ public class ConverterTest {
               arraySchema, List.of(1768478400000L, 1784116800000L), false);
 
       assertEquals(2, result.size());
-      assertEquals("2026-01-15T12:00:00", result.get(0).asText());
-      assertEquals("2026-07-15T12:00:00", result.get(1).asText());
+      assertEquals("2026-01-15T12:00:00Z", result.get(0).asText());
+      assertEquals("2026-07-15T12:00:00Z", result.get(1).asText());
     } finally {
       TimeZone.setDefault(original);
     }


### PR DESCRIPTION
## Problem
`RecordService.convertDebeziumTimestampToTextNode` emitted an **offset-less** local date-time (`ISO_LOCAL_DATE_TIME`, e.g. `2025-03-09T02:30:00.123456789`). Debezium `Timestamp`/`Micro`/`Nano` are epoch-based **UTC instants**, so the offset-less string is ambiguous — the Snowpipe Streaming ingest SDK (4.4.2) parses it via `LocalDateTime.atZone(<hardcoded America/Los_Angeles default>)`, which **DST-shifts +1h** on typed TIMESTAMP columns.

**Verified on dev:** Oracle `TIMESTAMP(9)` (`io.debezium.time.NanoTimestamp` = `2025-03-09 02:30:00.123456789 UTC`) landed in `TIMESTAMP_NTZ(9)` as `2025-03-09 03:30:00.123456789` (+1h; nanos preserved). The LA default is baked into the SDK, so this affects **all tenants** regardless of account settings. Only bites at DST gap/overlap windows → subtle.

## Fix
`ISO_LOCAL_DATE_TIME` → `ISO_OFFSET_DATE_TIME` (`…Z`). Same fraction handling (nanoseconds preserved); the SDK now takes its `OffsetDateTime`/UTC branch — no `atZone`, no shift, native TIMESTAMP type kept. One line, in our own Streamkap-authored helper (0 occurrences in upstream) — not the SDK or the failover-churned channel code. `TIME`/`DATE` helpers stay offset-less by design.

## Scope
Affects only **un-SMT'd** Debezium temporals into **typed** TIMESTAMP columns (chiefly `Nano*`, and any temporal on SMT-less destinations e.g. Iceberg). SMT'd `Timestamp`/`MicroTimestamp` (numeric-epoch path) and `ZonedTimestamp` (offset-bearing) are unaffected.

## Backward-compat
Typed TIMESTAMP columns: the `Z` is consumed by the SDK parse → **no stored change**. Only **VARIANT-nested** temporals (arrays/structs) gain a trailing `Z` in stored text (arguably a consistency improvement; `TRY_TO_TIMESTAMP` unaffected). No VARCHAR-timestamps (the mapper never emits them).

## Tests
`ConverterTest` DST-boundary assertions updated to expect the offset; added scalar **Micro/Nano** DST spring-forward-gap coverage at full precision. Full `records` suite green (JDK 17; the 5 unrelated errors are the known Mockito/warehouse-IT env failures).

Rolls into `snowflake-v3.2.2`; will forward-merge into `snowflake-v3.5.4`.

Linear: https://linear.app/streamkap/issue/ENG-2589

🤖 Generated with [Claude Code](https://claude.com/claude-code)