### PR TITLE
ENG-2596: map Kafka Decimal to DECIMAL(38,7) for Iceberg tables

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/schemaevolution/iceberg/IcebergColumnTreeFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/schemaevolution/iceberg/IcebergColumnTreeFactory.java
@@ -19,7 +19,8 @@ public class IcebergColumnTreeFactory {
   private final IcebergColumnTypeMapper mapper;
 
   public IcebergColumnTreeFactory() {
-    this.mapper = new IcebergColumnTypeMapper();
+    // Streamkap override (ENG-2596): maps Kafka Decimal to DECIMAL(38,7), matching classic tables.
+    this.mapper = new StreamkapIcebergColumnTypeMapper();
   }
 
   IcebergColumnTree fromIcebergSchema(IcebergColumnSchema columnSchema) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/schemaevolution/iceberg/StreamkapIcebergColumnTypeMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/schemaevolution/iceberg/StreamkapIcebergColumnTypeMapper.java
@@ -1,0 +1,34 @@
+package com.snowflake.kafka.connector.internal.streaming.schemaevolution.iceberg;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * Streamkap override of {@link IcebergColumnTypeMapper}. Keeps fork customisations out of the
+ * upstream mapper so future Snowflake merges stay low-conflict (see package CLAUDE.md).
+ *
+ * <p>ENG-2596: upstream maps a Kafka {@code Decimal} to {@code VARCHAR} for Iceberg tables, whereas
+ * classic tables use the Streamkap mapping {@code DECIMAL(38,7)} (STR-3827 / ENG-2503). That made
+ * the same source column land as text on Iceberg but numeric on classic. Map it to
+ * {@code DECIMAL(38,7)} here so both destination types agree.
+ *
+ * <p>Applies only to columns the connector <em>creates</em> (schema evolution from the Kafka
+ * record schema). Columns that already exist are read back through
+ * {@code mapToColumnTypeFromIcebergSchema}, which preserves their declared {@code DECIMAL(p,s)}.
+ *
+ * <p>Carries the same caveat as the classic mapping: scale is capped at 7, so a source scale &gt; 7
+ * (or &gt; 31 integer digits) loses precision.
+ */
+class StreamkapIcebergColumnTypeMapper extends IcebergColumnTypeMapper {
+
+  /** Mirrors StreamkapSnowflakeColumnTypeMapper's classic-table Decimal mapping. */
+  private static final String STREAMKAP_DECIMAL = "DECIMAL(38,7)";
+
+  @Override
+  String mapToColumnTypeFromKafkaSchema(Schema.Type kafkaType, String schemaName) {
+    if (kafkaType == Schema.Type.BYTES && Decimal.LOGICAL_NAME.equals(schemaName)) {
+      return STREAMKAP_DECIMAL;
+    }
+    return super.mapToColumnTypeFromKafkaSchema(kafkaType, schemaName);
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/schemaevolution/iceberg/StreamkapIcebergColumnTypeMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/schemaevolution/iceberg/StreamkapIcebergColumnTypeMapperTest.java
@@ -1,0 +1,84 @@
+package com.snowflake.kafka.connector.internal.streaming.schemaevolution.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * ENG-2596: covers the Streamkap override mapping Kafka Decimal to DECIMAL(38,7) for Iceberg
+ * tables (parity with classic tables), and pins that every other mapping still delegates to
+ * upstream. Upstream behaviour is covered by {@link IcebergColumnTypeMapperTest}.
+ */
+class StreamkapIcebergColumnTypeMapperTest {
+
+  private final StreamkapIcebergColumnTypeMapper mapper = new StreamkapIcebergColumnTypeMapper();
+
+  @Test
+  void shouldMapDecimalToStreamkapDecimalInsteadOfVarchar() {
+    assertThat(mapper.mapToColumnTypeFromKafkaSchema(Schema.Type.BYTES, Decimal.LOGICAL_NAME))
+        .isEqualTo("DECIMAL(38,7)");
+  }
+
+  @Test
+  void shouldNotAffectNonDecimalBytes() {
+    // BYTES without the Decimal logical type must stay BINARY
+    assertThat(mapper.mapToColumnTypeFromKafkaSchema(Schema.Type.BYTES, null)).isEqualTo("BINARY");
+  }
+
+  @Test
+  void shouldNotAffectDecimalLogicalNameOnOtherKafkaTypes() {
+    // the override is keyed on BYTES + Decimal, not the logical name alone
+    assertThat(mapper.mapToColumnTypeFromKafkaSchema(Schema.Type.STRING, Decimal.LOGICAL_NAME))
+        .isEqualTo("VARCHAR");
+  }
+
+  /**
+   * Proves the override is actually wired into {@link IcebergColumnTreeFactory} — the injection
+   * point schema evolution goes through — rather than merely being correct in isolation.
+   */
+  @Test
+  void factoryShouldProduceStreamkapDecimalForAConnectDecimalField() {
+    IcebergColumnTreeFactory treeFactory = new IcebergColumnTreeFactory();
+    IcebergColumnTreeTypeBuilder typeBuilder = new IcebergColumnTreeTypeBuilder();
+
+    IcebergColumnTree tree =
+        treeFactory.fromConnectSchema(new Field("AMOUNT", 0, Decimal.schema(2)));
+
+    assertThat(typeBuilder.buildType(tree)).contains("DECIMAL(38,7)");
+  }
+
+  @ParameterizedTest(name = "should delegate {0}/{1} to upstream -> {2}")
+  @MethodSource("delegatedTypes")
+  void shouldDelegateEverythingElseToUpstream(
+      Schema.Type kafkaType, String schemaName, String expected) {
+    assertThat(mapper.mapToColumnTypeFromKafkaSchema(kafkaType, schemaName)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> delegatedTypes() {
+    return Stream.of(
+        Arguments.of(Schema.Type.INT8, null, "INT"),
+        Arguments.of(Schema.Type.INT16, null, "INT"),
+        Arguments.of(Schema.Type.INT32, Date.LOGICAL_NAME, "DATE"),
+        Arguments.of(Schema.Type.INT32, Time.LOGICAL_NAME, "TIME(6)"),
+        Arguments.of(Schema.Type.INT32, null, "INT"),
+        Arguments.of(Schema.Type.INT64, Timestamp.LOGICAL_NAME, "TIMESTAMP(6)"),
+        Arguments.of(Schema.Type.INT64, null, "LONG"),
+        Arguments.of(Schema.Type.FLOAT32, null, "FLOAT"),
+        Arguments.of(Schema.Type.FLOAT64, null, "DOUBLE"),
+        Arguments.of(Schema.Type.BOOLEAN, null, "BOOLEAN"),
+        Arguments.of(Schema.Type.STRING, null, "VARCHAR"),
+        Arguments.of(Schema.Type.MAP, null, "MAP"),
+        Arguments.of(Schema.Type.ARRAY, null, "ARRAY"),
+        Arguments.of(Schema.Type.STRUCT, null, "OBJECT"));
+  }
+}


### PR DESCRIPTION
## Problem
Iceberg tables use a **different, stock-upstream** column-type mapper than classic tables — `IcebergColumnTypeMapper` has no Streamkap override. Upstream maps `BYTES + Decimal` → **`VARCHAR`**, while classic uses the Streamkap mapping **`DECIMAL(38,7)`** (STR-3827 / ENG-2503).

Net effect: the same source column lands as **text on Iceberg** but **numeric on classic** — numeric queries and downstream models need casting on the Iceberg side. Relevant to tenants moving onto Snowflake-native Iceberg.

## Fix
Fork convention — extend, don't modify (package `CLAUDE.md`):
- **New `StreamkapIcebergColumnTypeMapper`** overrides `mapToColumnTypeFromKafkaSchema`: returns `DECIMAL(38,7)` for `BYTES + Decimal.LOGICAL_NAME`, delegates everything else to `super`. Same package, so **no upstream visibility change was needed** (unlike ENG-2504).
- **`IcebergColumnTreeFactory`** injects it — the **only upstream line touched**.

## Scope
Applies to columns the connector **creates** via schema evolution (`resolveIcebergSchemaFromRecord` → `fromConnectSchema`). Columns that already exist are read back through `mapToColumnTypeFromIcebergSchema`, which already preserves their declared `DECIMAL(p,s)` — so **pre-declared decimal columns worked before this change and are unaffected**.

Value side already cooperates: `RecordService` emits `BYTES+Decimal` as a JSON **number** (`numberNode(bigDecimalValue)`), a natural fit for a DECIMAL column.

Carries the same caveat as classic: scale capped at 7 (ENG-2503).

## Tests
Upstream `IcebergColumnTypeMapperTest` left **byte-identical** (still asserts VARCHAR for the stock class). New `StreamkapIcebergColumnTypeMapperTest` (18) covers the override, non-decimal BYTES, the logical-name-on-other-types case, full delegation of every other type, **and a factory-level test proving the injection is actually wired** — verified it fails with `VARCHAR` when the injection is removed. Full iceberg + records suites green on JDK 17 (the 5 errors are the known Mockito/warehouse-`IT` env failures).

## Rollout
**`snowflake-v3.5.4` only — deliberately not backported to `snowflake-v3.2.2`** (the currently-deployed fleet baseline).

Debezium **temporal** parity for Iceberg is the natural follow-on, held pending the extended Iceberg QA — see ENG-2596.

Linear: https://linear.app/streamkap/issue/ENG-2596

🤖 Generated with [Claude Code](https://claude.com/claude-code)